### PR TITLE
resolveLook for single children and their descendants 

### DIFF
--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -64,11 +64,7 @@ export default function resolveLook(container, element, selectors, childProps) {
 					}
 				});
 			} else {
-				if (props.hasOwnProperty('look')) {
 					children = resolveLook(container, props.children, selectors);
-				} else {
-					children = props.children;
-				}
 			}
 		}
 


### PR DESCRIPTION
This change fixes the situation for single children in resolveLook. If it's a single child we should recurse on it and it's descendants regardless of whether parent has a look prop. Seems like the if block for an array of children was fine.