### PR TITLE
Null equal condition fix

### DIFF
--- a/src/utils/splitCondition.js
+++ b/src/utils/splitCondition.js
@@ -14,7 +14,7 @@ export default function splitCondition(key, operator, Component) {
 		let match = matchValues[property] === undefined ? 'undefined' : matchValues[property]
 
 		if (!isNumber(match)) {
-			match = match.toString()
+			match = (match + '').toString()
 		}
 		return [match, value]
 	} else {

--- a/test/mixins/condition-test.js
+++ b/test/mixins/condition-test.js
@@ -7,12 +7,13 @@ describe('Evaluating conditions', () => {
 			props: {
 				highlight: true,
 				clicks: 20,
-				noprop: undefined
+				noprop: undefined,
+				error: null
 			},
 			state: {}
 		}
 	}
-	
+
 	//Separating mixin functions for better testing
 	let equal, greater, unEqual, greaterThan, less, lessThan
 	Conditions.forEach(mixin => {
@@ -37,7 +38,7 @@ describe('Evaluating conditions', () => {
 				break
 		}
 	})
-	
+
 	it('should validate true', () => {
 		expect(equal('highlight=true', true, args)).to.equal(true)
 		expect(greater('clicks>10', true, args)).to.equal(true)
@@ -46,6 +47,7 @@ describe('Evaluating conditions', () => {
 		expect(greaterThan('clicks>=19', true, args)).to.equal(true)
 		expect(equal('noprop=undefined', true, args)).to.equal(true)
 		expect(unEqual('clicks!=undefined', true, args)).to.equal(true)
+		expect(equal('error=null', true, args)).to.equal(true)
 	})
 
 
@@ -55,5 +57,6 @@ describe('Evaluating conditions', () => {
 		expect(unEqual('clicks!=20', true, args)).to.equal(false)
 		expect(lessThan('clicks<=10', true, args)).to.equal(false)
 		expect(equal('highlight=undefined', true, args)).to.equal(false)
+		expect(equal('error=undefined', true, args)).to.equal(false)
 	})
 })


### PR DESCRIPTION
I found a bug when one of my properties was null and trying to evaluate it in the properties.

My styles looked like this:

```js
  styles = {
    error: {
      backgroundColor: '#ff4136',
      color: '#ffffff',
      padding: '20px 10px',
      fontSize: '1.25rem',
      'error=undefined': {
        display: 'none',
      },
    },
  }
```

And somehow the `error` prop came in as null and was throwing an exception when trying to call `.toString()` on `null`.

I committed first a failing test, and then the code to make the test pass.