### PR TITLE
Pseudo :valid and :invalid selectors

### DIFF
--- a/examples/pseudo/Input.jsx
+++ b/examples/pseudo/Input.jsx
@@ -8,10 +8,11 @@ export default class Input extends Component {
     return (
       <div>
         <input key="i1" look={[styles.input, styles.inputFocus]} placeholder="focus me"/>
-      <input look={styles.input} placeholder="i am required" required/>
-    <input look={[styles.input, styles.inputOptional]} placeholder="i am optional"/>
-  <input look={[styles.input, styles.readOnly]} placeholder="i am read only" readOnly/>
-<input disabled look={[styles.input, styles.inputDisabled]} placeholder="i am disabled"/>
+        <input look={styles.input} placeholder="i am required" required/>
+        <input look={styles.input} placeholder="i have pattern" pattern="[A-Z]" ref="valid"/>
+        <input look={[styles.input, styles.inputOptional]} placeholder="i am optional"/>
+        <input look={[styles.input, styles.readOnly]} placeholder="i am read only" readOnly/>
+        <input disabled look={[styles.input, styles.inputDisabled]} placeholder="i am disabled"/>
         <input ref="email" type="email" look={styles.input} placeholder="i am an email"/>
         <input ref="email-multiple" type="email" multiple look={styles.input} placeholder="i am multiple emails"/>
         <input ref="url" type="url" look={styles.input} placeholder="i am an url"/>

--- a/examples/pseudo/Input.jsx
+++ b/examples/pseudo/Input.jsx
@@ -16,6 +16,8 @@ export default class Input extends Component {
         <input ref="email" type="email" look={styles.input} placeholder="i am an email"/>
         <input ref="email-multiple" type="email" multiple look={styles.input} placeholder="i am multiple emails"/>
         <input ref="url" type="url" look={styles.input} placeholder="i am an url"/>
+        <input ref="maxlength" maxLength="3" look={styles.input} placeholder="i have maxlength"/>
+        <input ref="minlength" minLength="3" look={styles.input} placeholder="i have minlength"/>
       </div>
     )
   }

--- a/examples/pseudo/Input.jsx
+++ b/examples/pseudo/Input.jsx
@@ -12,6 +12,9 @@ export default class Input extends Component {
     <input look={[styles.input, styles.inputOptional]} placeholder="i am optional"/>
   <input look={[styles.input, styles.readOnly]} placeholder="i am read only" readOnly/>
 <input disabled look={[styles.input, styles.inputDisabled]} placeholder="i am disabled"/>
+        <input ref="email" type="email" look={styles.input} placeholder="i am an email"/>
+        <input ref="email-multiple" type="email" multiple look={styles.input} placeholder="i am multiple emails"/>
+        <input ref="url" type="url" look={styles.input} placeholder="i am an url"/>
       </div>
     )
   }

--- a/examples/pseudo/Input.jsx
+++ b/examples/pseudo/Input.jsx
@@ -30,6 +30,9 @@ const styles = StyleSheet.create(Input, {
     userSelect: 'text',
     ':required': {
       border: '2px solid black'
+    },
+    ':valid': {
+      backgroundColor: 'green'
     }
   },
   inputFocus: {

--- a/src/addons.js
+++ b/src/addons.js
@@ -7,7 +7,7 @@ import { equal, unEqual, greater, less, greaterThan, lessThan } from './properti
 import { firstChild, lastChild, onlyChild, nthChild, nthLastChild } from './properties/pseudoClasses/childIndex'
 import { firstOfType, lastOfType, onlyOfType, nthOfType, nthLastOfType } from './properties/pseudoClasses/childTypeIndex'
 import { checked, disabled, enabled, required, optional, readOnly, readWrite, indeterminate } from './properties/pseudoClasses/input'
-import { hover, active, focus } from './properties/pseudoClasses/userAction'
+import { hover, active, focus, valid } from './properties/pseudoClasses/userAction'
 import { before, after } from './properties/pseudoClasses/beforeAfter'
 import lang from './properties/pseudoClasses/lang'
 import empty from './properties/pseudoClasses/empty'
@@ -56,6 +56,7 @@ export default {
     readWrite,
     required,
     optional,
-    indeterminate
+    indeterminate,
+    valid
   }
 }

--- a/src/preconfig/dom.js
+++ b/src/preconfig/dom.js
@@ -8,7 +8,7 @@ import { equal, unEqual, greater, less, greaterThan, lessThan } from '../propert
 import { firstChild, lastChild, onlyChild, nthChild, nthLastChild } from '../properties/pseudoClasses/childIndex'
 import { firstOfType, lastOfType, onlyOfType, nthOfType, nthLastOfType } from '../properties/pseudoClasses/childTypeIndex'
 import { checked, disabled, enabled, required, optional, readOnly, readWrite, indeterminate } from '../properties/pseudoClasses/input'
-import { hover, active, focus } from '../properties/pseudoClasses/userAction'
+import { hover, active, focus, valid } from '../properties/pseudoClasses/userAction'
 import { before, after } from '../properties/pseudoClasses/beforeAfter'
 import lang from '../properties/pseudoClasses/lang'
 import empty from '../properties/pseudoClasses/empty'
@@ -59,6 +59,7 @@ export default {
     ':read-write': readWrite,
     ':required': required,
     ':optional': optional,
-    ':indeterminate': indeterminate
+    ':indeterminate': indeterminate,
+    ':valid': valid
   }
 }

--- a/src/properties/pseudoClasses/userAction.js
+++ b/src/properties/pseudoClasses/userAction.js
@@ -87,6 +87,10 @@ const valid = (property, styles, customKey, {element, Component, newProps}) => {
       isValid = false
     }
 
+    if ( input.pattern && !new RegExp(input.pattern).test(input.value) ) {
+      isValid = false
+    }
+
     State.setState('valid', isValid, Component, key)
   })
   // resolving browser State

--- a/src/properties/pseudoClasses/userAction.js
+++ b/src/properties/pseudoClasses/userAction.js
@@ -117,6 +117,14 @@ const valid = (property, styles, customKey, {element, Component, newProps}) => {
       isValid = false
     }
 
+    if ( input.minLength && input.value.length < parseInt(input.minLength, 10) ) {
+      isValid = false
+    }
+
+    if ( input.maxLength && input.value.length > parseInt(input.maxLength, 10) ) {
+      isValid = false
+    }
+
     State.setState('valid', isValid, Component, key)
   })
   // resolving browser State

--- a/src/properties/pseudoClasses/userAction.js
+++ b/src/properties/pseudoClasses/userAction.js
@@ -71,4 +71,26 @@ const focus = (property, styles, customKey, {element, Component, newProps}) => {
   return State.getState('focus', Component, key) ? styles : false
 }
 
-export default {active, focus, hover}
+
+const valid = (property, styles, customKey, {element, Component, newProps}) => {
+  const key = element.key || element.ref || defaultKey
+
+  // add event listener if not added yet
+  newProps.onKeyUp = createListener(Component, element, key, 'onKeyDown', () => {
+    const { refs } = Component
+    const ref = Object.keys(refs).pop()
+    const { [ref]: input } = refs
+
+    let isValid = true
+
+    if ( input.required && !input.value ) {
+      isValid = false
+    }
+
+    State.setState('valid', isValid, Component, key)
+  })
+  // resolving browser State
+  return State.getState('valid', Component, key) ? styles : false
+}
+
+export default {active, focus, hover, valid}

--- a/test/properties/pseudoClasses/userAction-test.js
+++ b/test/properties/pseudoClasses/userAction-test.js
@@ -1,4 +1,4 @@
-import { hover, focus, active } from '../../../lib/properties/pseudoClasses/userAction'
+import { hover, focus, active, valid } from '../../../lib/properties/pseudoClasses/userAction'
 import State from '../../../lib/api/State'
 import { expect } from 'chai'
 
@@ -60,6 +60,20 @@ describe('Evaluating active pseudos', () => {
 
   it('should add a mouseDown listener', () => {
     expect(args.newProps).to.have.property('onMouseDown')
+  })
+
+  it('should set an initial state', () => {
+    expect(State.has(args.Component, args.element.key)).to.equal(true)
+    expect(State.get(args.Component, args.element.key)).to.eql({})
+  })
+})
+
+describe('Evaluating valid pseudos', () => {
+
+  valid(':valid', true, ':valid', args)
+
+  it('should add a keyUp listener', () => {
+    expect(args.newProps).to.have.property('onKeyUp')
   })
 
   it('should set an initial state', () => {


### PR DESCRIPTION
Started progress towards #74 here. Pulling information from the [spec](https://html.spec.whatwg.org/multipage/forms.html#candidate-for-constraint-validation).

- [x] required
- [x] type mismatch (email, URL)
- [x] pattern
- [x] too long (maxlength)
- [x] too short (minlength)
- [x] underflow ([min](https://html.spec.whatwg.org/multipage/forms.html#attr-input-min))
- [x] overflow ([max](https://html.spec.whatwg.org/multipage/forms.html#attr-input-max))
- [ ] step mismatch (doesn't fit rules for [step](https://html.spec.whatwg.org/multipage/forms.html#attr-input-step))
- [ ] bad input (see everything referenced [here](https://html.spec.whatwg.org/multipage/forms.html#suffering-from-bad-input))
- [ ] custom error (see [setCustomValidity()](https://html.spec.whatwg.org/multipage/forms.html#dom-cva-setcustomvalidity)

