### PR TITLE
Add UMD library build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ lib/
 demo/bundle.js
 coverage
 addons/
+dist/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "license": "MIT",
   "repository": "https://github.com/rofrischmann/react-look",
   "scripts": {
-    "clean": "rimraf coverage",
+    "clean": "rimraf coverage dist",
+    "umd": "NODE_ENV=development webpack packages/react-look/modules/index.js dist/react-look.js",
+    "umd:min": "NODE_ENV=production webpack packages/react-look/modules/index.js dist/react-look.min.js",
     "build": "./scripts/buildPackages.sh",
     "coverage": "codeclimate-test-reporter < coverage/lcov.info",
     "lint": "./scripts/lintPackages.sh",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,59 @@
+var webpack = require('webpack')
+var path = require('path')
+
+var conf = {
+  resolve: {
+    extensions: [ '', '.js', '.jsx' ],
+    alias: {
+      'react-look-core': path.join(__dirname, 'packages/react-look-core/modules/index.js')
+    }
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        loader: 'babel-loader',
+        include: [
+          path.join(__dirname, 'packages/react-look-core'),
+          path.join(__dirname, 'packages/react-look')
+        ],
+        exclude: /node_modules/
+      }
+    ]
+  },
+  externals: {
+    // Expect react to be imported beforehand. On the browser it's imported as 'React'.
+    react: {
+      root: 'React',
+      commonjs2: 'react',
+      commonjs: 'react',
+      amd: 'react'
+    }
+  },
+  output: {
+    library: 'react-look',
+    libraryTarget: 'umd'
+  },
+  plugins: [
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': process.env.NODE_ENV
+    })
+  ]
+}
+
+if (process.env.NODE_ENV === 'production') {
+  conf.plugins.push(
+    new webpack.optimize.UglifyJsPlugin({
+      compressor: {
+        pure_getters: true,
+        unsafe: true,
+        unsafe_comps: true,
+        screw_ie8: true,
+        warnings: false
+      }
+    })
+  );
+}
+
+module.exports = conf


### PR DESCRIPTION
It's starting the build with the root package.json `umd` and `umd:min` tasks and build into `dist/`.

I don't know how useful this is at the time, or in its current state. Just shoot me a message with your requirements for this. ;)

```
This should use the existing version of webpack and
configuration for babel to build an UMD library version
of React Look.

The React package is externalised. This means that if
the UMD file is used, React must be already present
as either a commonjs2 or amd import or in the global
root var as 'React'.

Lodash on the other hand is not externalised, as the
babel plugin takes care of including only the methods
that are actually in use.
```
