### PR TITLE
Be able to change class prefix

### DIFF
--- a/packages/react-look/modules/api/StyleContainer.js
+++ b/packages/react-look/modules/api/StyleContainer.js
@@ -21,6 +21,7 @@ class StyleContainer {
     this.statics = new Set()
 
     this._className = 0
+    this._defaultClassPrefix = 'c'
     this._listener = new Set()
   }
 
@@ -104,7 +105,7 @@ class StyleContainer {
  	 * Returns a valid unused className
  	 * @param {string?} prefix - prefix appended before the className
  	 */
-  requestClassName(prefix = 'c') {
+  requestClassName(prefix = this._defaultClassPrefix) {
     return prefix + (this._className++).toString(36)
   }
 


### PR DESCRIPTION
Made the default prefix to an class attribute => can now be changed from the outside

Would be very useful, to change classnames during server rendering.
