### PR TITLE
add multi-line support for addCSS

### DIFF
--- a/packages/react-look/modules/api/StyleContainer.js
+++ b/packages/react-look/modules/api/StyleContainer.js
@@ -63,7 +63,7 @@ class StyleContainer {
    * @param {string} styles - as css string
    */
   addStatic(styles) {
-    this._addAndEmit(this.statics, styles.replace(/\s/g, ''))
+    this._addAndEmit(this.statics, styles.replace(/\s+/g, ''))
   }
 
   /**

--- a/packages/react-look/modules/api/StyleContainer.js
+++ b/packages/react-look/modules/api/StyleContainer.js
@@ -63,7 +63,7 @@ class StyleContainer {
    * @param {string} styles - as css string
    */
   addStatic(styles) {
-    this._addAndEmit(this.statics, styles)
+    this._addAndEmit(this.statics, styles.replace(/\s/g, ''))
   }
 
   /**

--- a/packages/react-look/test/api/StyleContainer-test.js
+++ b/packages/react-look/test/api/StyleContainer-test.js
@@ -36,10 +36,11 @@ describe('Adding a static css string with spaces and comments', () => {
      *  Banner
      */
     .h1 { 
-      color: red; 
+      color: red;
+      margin: 10px 10px 10px 10px;
     }`
     StyleContainer.addStatic(css)
-    expect(StyleContainer.statics.has(css.replace(/\s/g, ''))).to.eql(true)
+    expect(StyleContainer.statics.has(css.replace(/\s+/g, ''))).to.eql(true)
   })
 })
 

--- a/packages/react-look/test/api/StyleContainer-test.js
+++ b/packages/react-look/test/api/StyleContainer-test.js
@@ -25,7 +25,21 @@ describe('Adding a static css string', () => {
   it('should add it to the statics set', () => {
     const css = '.h1 { color: red }'
     StyleContainer.addStatic(css)
-    expect(StyleContainer.statics.has(css)).to.eql(true)
+    expect(StyleContainer.statics.has('.h1{color:red}')).to.eql(true)
+  })
+})
+
+describe('Adding a static css string with spaces and comments', () => {
+  it('should add it to the statics set', () => {
+    const css = `
+    /*!
+     *  Banner
+     */
+    .h1 { 
+      color: red; 
+    }`
+    StyleContainer.addStatic(css)
+    expect(StyleContainer.statics.has(css.replace(/\s/g, ''))).to.eql(true)
   })
 })
 

--- a/packages/react-look/test/api/StyleSheet-test.js
+++ b/packages/react-look/test/api/StyleSheet-test.js
@@ -50,13 +50,13 @@ describe('Generating global CSS', () => {
   it('should treat strings as static css', () => {
     const css = 'h1 { color: blue }'
     StyleSheet.addCSS(css)
-    expect(StyleContainer.statics.has(css)).to.eql(true)
+    expect(StyleContainer.statics.has('h1{color:blue}')).to.eql(true)
   })
 
   it('toCSS should just call addCSS', () => {
     const css = 'h1 { color: blue }'
     StyleSheet.toCSS(css)
-    expect(StyleContainer.statics.has(css)).to.eql(true)
+    expect(StyleContainer.statics.has('h1{color:blue}')).to.eql(true)
   })
 })
 


### PR DESCRIPTION
just a little change to make it super convenient to copy n paste css files into the `addCSS` method.
A good idea for a future PR might be to also remove comments (https://github.com/sindresorhus/strip-css-comments), but I wanted to start small.

FYI there was a test that was failing before this commit & it's still failing. 
