### PR TITLE
Incremented version to `1.0.0-beta9`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.0.0-beta8",
+  "version": "1.0.0-beta9",
   "author": "Robin Frischmann <robin@rofrischmann.de>",
   "license": "MIT",
   "repository": "https://github.com/rofrischmann/react-look",


### PR DESCRIPTION
I forgot to increment the package version when I submitted the last PR with the updated react package versions. Would you mind merging this in, so I can get these updates via npm?
