### PR TITLE
Prefer writing to textContent instead of innerText

### DIFF
--- a/packages/react-look/modules/api/LookRoot.js
+++ b/packages/react-look/modules/api/LookRoot.js
@@ -77,6 +77,10 @@ class StyleComponent {
   }
 
   render() {
-    this.el.innerText = this.styles
+    if ('textContent' in this.el) {
+      this.el.textContent = this.styles
+    } else {
+      this.el.innerText = this.styles
+    }
   }
 }


### PR DESCRIPTION
`innerText` has been discouraged for a while now, and some browsers ([Waterfox](https://www.waterfoxproject.org)) have removed support for it.  I _think_ it's also blocked by an `unsafe-inline` CSP (but forget offhand)

This change keeps writing to it, just in case.  But, [IE9+ supports `textContent`](http://caniuse.com/#search=textContent), so that may be overkill.  What's the min supported IE for react-look?
