### PR TITLE
React Native: React API must be required from react since RN v0.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react-look": "^1.0.0-beta9",
     "react-look-core": "^1.0.0-beta9",
     "react-look-test-utils": "^1.0.0-beta9",
-    "react-native": "^0.20.0",
+    "react-native": "^0.26.0",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "webpack": "^1.12.11",

--- a/packages/react-look-native/README.md
+++ b/packages/react-look-native/README.md
@@ -71,7 +71,8 @@ The syntax is quite similar to [Sass](http://sass-lang.com) and other React styl
 npm install react-look-native --save
 ```
 ```javascript
-import React, { View, Text, Component, PropTypes } from 'react-native'
+import React, { Component, PropTypes } from 'react'
+import { View, Text } from 'react-native'
 import look, { StyleSheet } from 'react-look-native'
 
 class Header extends Component {
@@ -117,7 +118,8 @@ export default look(Header)
 Finally you only need to wrap your application with LookRoot.
 ```javascript
 import { Presets,  LookRoot } from 'react-look-native'
-import React, { AppRegistry, Component }  from 'react-native'
+import React, { Component } from 'react'
+import { AppRegistry }  from 'react-native'
 import Header from './Header'
 
 // A simple basic app just showing the Header with "Hello World"

--- a/packages/react-look-native/docs/GettingStarted.md
+++ b/packages/react-look-native/docs/GettingStarted.md
@@ -32,7 +32,8 @@ Now its time to compose your first Component. <br>
 You basically start with a blank `React` Component that renders some markup.
 
 ```javascript
-import React, { View, Component } from 'react-native'
+import React, { Component } from 'react'
+import { View } from 'react-native'
 
 export default class FirstComponent extends Component {
 	render() {
@@ -47,7 +48,8 @@ We use the `StyleSheet.create` helper with React Native, but it does (by now) on
 
 ```javascript
 import { StyleSheet } from 'react-look-native'
-import React, { View, Component } from 'react-native'
+import React, { Component } from 'react'
+import { View } from 'react-native'
 
 export default class FirstComponent extends Component {
 	render() {
@@ -70,7 +72,8 @@ You can even have multiple styles assigned to a single node as well as multiple 
 
 ```javascript
 import { StyleSheet } from 'react-look-native'
-import React, { View, Text, Component } from 'react-native'
+import React, { Component } from 'react'
+import { View, Text } from 'react-native'
 // We use this shortcut to write less code
 const c = StyleSheet.combineStyles
 
@@ -108,7 +111,8 @@ With Look you can easily style even **[Stateless Components](http://facebook.git
 
 ```javascript
 import { StyleSheet } from 'react-look-native'
-import React, { View, Component } from 'react-native'
+import React, { Component } from 'react'
+import { View } from 'react-native'
 
 export default ({title}) => <View style={styles.box}>{title}</View>
 
@@ -132,7 +136,8 @@ We will use a preset which provides every mixin & plugin available. We will refe
 
 ```javascript
 import { Presets, LookRoot } from 'react-look-native'
-import React, { AppRegistry }  from 'react-native'
+import React from 'react'
+import { AppRegistry }  from 'react-native'
 
 const config = Presets['react-native']
 
@@ -144,7 +149,8 @@ Resolving mixins and plugins requires your Component to be wrapped with the `loo
 
 ```javascript
 import look from 'react-look-native'
-import React, { View, Component } from 'react-native'
+import React, { Component } from 'react'
+import { View } from 'react-native'
 
 class FirstComponent extends Component {
 	render() {
@@ -161,7 +167,8 @@ Though I do not recommend this as they neither are part of the ECMAScript 2015 s
 
 ```javascript
 import look from 'react-look-native'
-import React, { View, Component } from 'react-native'
+import React, { Component } from 'react'
+import { View } from 'react-native'
 
 @look
 export default class FirstComponent extends Component {
@@ -177,7 +184,8 @@ Now as you got all the configuration and wrapping done, simply start using mixin
 
 ```javascript
 import look, { StyleSheet } from 'react-look-native'
-import React, { View, Component, TouchableHighlight } from 'react-native'
+import React, { Component } from 'react'
+import { View, TouchableHighlight } from 'react-native'
 
 // Note that now you can export directly
 @look

--- a/packages/react-look-native/docs/api/LookRoot.md
+++ b/packages/react-look-native/docs/api/LookRoot.md
@@ -10,8 +10,9 @@
 
 ## Usage
 ```javascript
+import React, { Component } from 'react'
 import { Presets, Plugins, LookRoot } from 'react-look-native'
-import React, { AppRegistry, Component }  from 'react-native'
+import { AppRegistry }  from 'react-native'
 import App from './index'
 
 const composedConfig = Presets['react-native']

--- a/packages/react-look-native/modules/api/LookRoot.js
+++ b/packages/react-look-native/modules/api/LookRoot.js
@@ -1,4 +1,4 @@
-import { Component, PropTypes } from 'react-native'
+import { Component, PropTypes } from 'react'
 import _ from 'lodash'
 
 import resolveStyles from '../core/resolver'

--- a/packages/react-look-native/modules/core/resolver.js
+++ b/packages/react-look-native/modules/core/resolver.js
@@ -1,4 +1,4 @@
-import { cloneElement } from 'react-native'
+import { cloneElement } from 'react'
 import _ from 'lodash'
 
 import { resolver } from 'react-look-core'

--- a/packages/react-look-native/modules/mixins/beforeAfter.js
+++ b/packages/react-look-native/modules/mixins/beforeAfter.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
-import { createElement, Text } from 'react-native'
+import { createElement } from 'react'
+import { Text } from 'react-native'
 
 /**
  * Creates a new pseudo element

--- a/packages/react-look-native/modules/mixins/firstLetter.js
+++ b/packages/react-look-native/modules/mixins/firstLetter.js
@@ -1,4 +1,5 @@
-import { createElement, Text } from 'react-native'
+import { createElement } from 'react'
+import { Text } from 'react-native'
 
 // Styles the first letter of an element
 export default ({ value, newProps }) => {

--- a/packages/react-look-native/modules/mixins/substr.js
+++ b/packages/react-look-native/modules/mixins/substr.js
@@ -1,4 +1,5 @@
-import { createElement, Text } from 'react-native'
+import { createElement } from 'react'
+import { Text } from 'react-native'
 import _ from 'lodash'
 
 import { Utils } from 'react-look-core'

--- a/packages/react-look-native/package.json
+++ b/packages/react-look-native/package.json
@@ -32,6 +32,6 @@
         "lodash": "^4.2.1"
     },
     "peerDependencies": {
-        "react-native": "^0.18.0"
+        "react-native": "^0.26.0"
     }
 }

--- a/packages/react-look-native/test/index-test.js
+++ b/packages/react-look-native/test/index-test.js
@@ -1,5 +1,5 @@
 import look from '../modules'
-import React, { Component } from 'react-native'
+import React, { Component } from 'react'
 
 describe('Enhancing with look', () => {
   it('should work as a higher order function', () => {


### PR DESCRIPTION
`react-look-native` currently doesn't work with any version of `react-native` beyond 0.25.0, as `react-native` migrated to using core API features directly from the `react` NPM package instead of embedding `react` with `react-native`.

Verified all code changes worked on the latest stable release of RN (v0.29.2) and ran the `react-look` test coverage, which completely passed.
