### PR TITLE
Add _selector to React Native's style propTypes to fix debugger warnings

### DIFF
--- a/packages/react-look-native/modules/api/StyleSheet.js
+++ b/packages/react-look-native/modules/api/StyleSheet.js
@@ -1,6 +1,16 @@
 import _ from 'lodash'
-
 import renderStaticStyles from '../core/renderer'
+import { PropTypes } from 'react'
+import TextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes'
+import ViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'
+import StyleSheetValidation from 'react-native/Libraries/StyleSheet/StyleSheetValidation'
+
+TextStylePropTypes._selector = PropTypes.array
+ViewStylePropTypes._selector = PropTypes.array
+
+StyleSheetValidation.addValidStylePropTypes({
+  _selector: PropTypes.array
+})
 
 export default {
   create(styles) {


### PR DESCRIPTION
Really simple fix for the debugger warnings about props.style key `_selector`.
