### PR TITLE
Fix for warning after upgrade to React 0.15.2.

### DIFF
--- a/packages/react-look-core/modules/core/enhancer.js
+++ b/packages/react-look-core/modules/core/enhancer.js
@@ -32,7 +32,6 @@ export default (CustomComponent, config = { }) => {
 
     // Passing contextTypes to be able to reference context
     LookStateless.contextTypes = _.merge({ }, CustomComponent.contextTypes, contextType)
-    LookStateless.childContextTypes = _.merge({ }, CustomComponent.childContextTypes, contextType)
 
     // Flag as Look-enhanced Component
     LookStateless._isLookEnhanced = true


### PR DESCRIPTION
Guten Morgen vom Flughafen Leipzig!

Closes issue #299. Squelches messages like:

`warning.js:44 Warning: LookStateless(...): childContextTypes cannot be defined on a functional component.`
